### PR TITLE
Prevent infinite loop on Index Error

### DIFF
--- a/enocean/communicators/serialcommunicator.py
+++ b/enocean/communicators/serialcommunicator.py
@@ -39,7 +39,7 @@ class SerialCommunicator(Communicator):
             try:
                 self.parse()
             except Exception as e:
-                self.logger.error('Exception occured while parsing: ' + str(e))
+                self.logger.exception('Exception occured while parsing: ')
             time.sleep(0)
 
         self.__ser.close()

--- a/enocean/protocol/packet.py
+++ b/enocean/protocol/packet.py
@@ -149,18 +149,21 @@ class Packet(object):
             return PARSE_RESULT.CRC_MISMATCH, buf, None
 
         # If we got this far, everything went ok (?)
-        if packet_type == PACKET.RADIO_ERP1:
-            # Need to handle UTE Teach-in here, as it's a separate packet type...
-            if data[0] == RORG.UTE:
-                packet = UTETeachInPacket(packet_type, data, opt_data)
+        try:
+            if packet_type == PACKET.RADIO_ERP1:
+                # Need to handle UTE Teach-in here, as it's a separate packet type...
+                if data[0] == RORG.UTE:
+                    packet = UTETeachInPacket(packet_type, data, opt_data)
+                else:
+                    packet = RadioPacket(packet_type, data, opt_data)
+            elif packet_type == PACKET.RESPONSE:
+                packet = ResponsePacket(packet_type, data, opt_data)
+            elif packet_type == PACKET.EVENT:
+                packet = EventPacket(packet_type, data, opt_data)
             else:
-                packet = RadioPacket(packet_type, data, opt_data)
-        elif packet_type == PACKET.RESPONSE:
-            packet = ResponsePacket(packet_type, data, opt_data)
-        elif packet_type == PACKET.EVENT:
-            packet = EventPacket(packet_type, data, opt_data)
-        else:
-            packet = Packet(packet_type, data, opt_data)
+                packet = Packet(packet_type, data, opt_data)
+        except IndexError:
+            return PARSE_RESULT.INCOMPLETE, buf, None
 
         return PARSE_RESULT.OK, buf, packet
 


### PR DESCRIPTION
This PR prevents an infinite loop on IndexError raised by `UTETeachInPacket` class. See [this discussion](https://github.com/mak-gitdev/HA_enoceanmqtt/discussions/111).

This error occurred once or twice a month on my setup. The HA_encoeanmqtt gateway was unusable after that and needed to be restarted.